### PR TITLE
Admin: Subscription onboarding Exception fix

### DIFF
--- a/CMP/CmpWap/CmpWapExtension/Api/CmpWapDb.cs
+++ b/CMP/CmpWap/CmpWapExtension/Api/CmpWapDb.cs
@@ -634,8 +634,7 @@ namespace Microsoft.WindowsAzurePack.CmpWapExtension.Api
                                     select new { Key = vmos, Value = mapTable == null ? false : mapTable.IsActive };
 
                     if (!vmOsQuery.Any())
-                        throw new Exception("FetchOsInfoList() : Unable to get VM OS records for the plan " + planId);
-
+                        return null;
 
                     foreach (var item in vmOsQuery.Distinct())
                     {
@@ -901,7 +900,7 @@ namespace Microsoft.WindowsAzurePack.CmpWapExtension.Api
                                         select new { Key = regions, Value = mapTable == null ? false : mapTable.IsActive };
 
                     if (!regionQuery.Any())
-                        throw new Exception("FetchAzureRegionList() : Unable to locate Region List for the plan " + planId);
+                        return null;
 
                     foreach (var item in regionQuery.Distinct())
                     {


### PR DESCRIPTION
Quick fix on this one. On mapping tables, we need to return a null instead of throwing an exception. The null (maybe it could be an empty set, but will check on a later release) signals that there's no mapping, so it gets created by the appropriate method. Throwing an exception here was a change made recently, and it interrupts the process.

For now, reverting back to how it was. We need to design this a little better if possible in a future release for better code style and clarity.